### PR TITLE
obsidian: wrap, conceallevel, and j/k visual-line nav for notes

### DIFF
--- a/after/ftplugin/markdown.vim
+++ b/after/ftplugin/markdown.vim
@@ -2,4 +2,3 @@ setlocal tabstop=2
 setlocal shiftwidth=2
 setlocal softtabstop=2
 
-setlocal conceallevel=2

--- a/lua/plugins/obsidian.lua
+++ b/lua/plugins/obsidian.lua
@@ -17,5 +17,13 @@ return {
         path = workspace_path,
       },
     },
+    callbacks = {
+      enter_note = function()
+        vim.opt_local.conceallevel = 1
+        vim.opt_local.wrap = true
+        vim.keymap.set("n", "j", "gj", { buffer = true, silent = true })
+        vim.keymap.set("n", "k", "gk", { buffer = true, silent = true })
+      end,
+    },
   },
 }


### PR DESCRIPTION
## Summary

- `after/ftplugin/markdown.vim`: removed explicit `conceallevel=2`, letting it fall back to vim's default of 0 for all non-obsidian markdown
- `lua/plugins/obsidian.lua`: added `callbacks.enter_note` that sets `conceallevel=1`, `wrap=true`, and remaps `j`/`k` to `gj`/`gk` (buffer-local) when entering an obsidian note

## Why

Conceallevel 2 was too aggressive for regular markdown files. Obsidian notes benefit from light concealment (level 1) plus line wrapping, but `j`/`k` jumping over multiple visual lines with wrapping enabled is painful — `gj`/`gk` fixes that.

Using `enter_note` callback rather than a `FileType` autocmd means the special behavior only applies to actual obsidian notes, not all markdown files that happen to be open when in the obsidian folder.